### PR TITLE
Fix: Compile time error in ConnectionManager::makeUnique

### DIFF
--- a/wangle/acceptor/ConnectionManager.h
+++ b/wangle/acceptor/ConnectionManager.h
@@ -60,8 +60,8 @@ class ConnectionManager: public folly::DelayedDestruction,
    */
   template<typename... Args>
   static UniquePtr makeUnique(Args&&... args) {
-    return folly::make_unique<ConnectionManager, Destructor>(
-      std::forward<Args>(args)...);
+    return std::unique_ptr<ConnectionManager, Destructor>(
+      new ConnectionManager(std::forward<Args>(args)...));
   }
 
   /**


### PR DESCRIPTION
ConnectionManager::makeUnique was calling folly::make_unique with an extra
template argument (destructor). It looks like the folly code use to accept this
in the past. Now folly updated it to be more C++14 standard compliant and it no
longer accepts second template argument.

http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique