### PR TITLE
Simple fix building error for OSX(just remove FileRegion when it is compiling on not Linux

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -43,6 +43,7 @@ foreach(dir ${WANGLE_HEADER_DIRS})
     ${headers})
 endforeach()
 
+if (LINUX)
 set(WANGLE_SOURCES
   acceptor/Acceptor.cpp
   acceptor/ConnectionManager.cpp
@@ -69,12 +70,40 @@ set(WANGLE_SOURCES
   ssl/SSLUtil.cpp
   ssl/TLSTicketKeyManager.cpp
 )
+else()
+set(WANGLE_SOURCES
+  acceptor/Acceptor.cpp
+  acceptor/ConnectionManager.cpp
+  acceptor/LoadShedConfiguration.cpp
+  acceptor/ManagedConnection.cpp
+  acceptor/SocketOptions.cpp
+  acceptor/SSLAcceptorHandshakeHelper.cpp
+  acceptor/TransportInfo.cpp
+  bootstrap/ServerBootstrap.cpp
+  channel/Pipeline.cpp
+  codec/LengthFieldBasedFrameDecoder.cpp
+  codec/LengthFieldPrepender.cpp
+  codec/LineBasedFrameDecoder.cpp
+  concurrent/CPUThreadPoolExecutor.cpp
+  concurrent/Codel.cpp
+  concurrent/GlobalExecutor.cpp
+  concurrent/IOThreadPoolExecutor.cpp
+  concurrent/ThreadPoolExecutor.cpp
+  deprecated/rx/Dummy.cpp
+  ssl/PasswordInFile.cpp
+  ssl/SSLContextManager.cpp
+  ssl/SSLSessionCacheManager.cpp
+  ssl/SSLUtil.cpp
+  ssl/TLSTicketKeyManager.cpp
+)
+endif()
 
 add_library(wangle STATIC
   ${WANGLE_HEADERS}
   ${WANGLE_SOURCES}
 )
 
+if(LINUX)
 target_link_libraries(wangle
   ${FOLLY_LIBRARIES}
   ${Boost_LIBRARIES}
@@ -82,6 +111,14 @@ target_link_libraries(wangle
   -lglog
   -lgflags
   -latomic)
+else()
+target_link_libraries(wangle
+  ${FOLLY_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${OPENSSL_LIBRARIES}
+  -lglog
+  -lgflags)
+endif()
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})

--- a/wangle/channel/FileRegion.h
+++ b/wangle/channel/FileRegion.h
@@ -17,6 +17,10 @@
 #include <folly/futures/Promise.h>
 #include <wangle/concurrent/IOThreadPoolExecutor.h>
 
+#ifndef __LINUX__
+#error "FileRegion can be supported by LINUX only"
+#endif
+
 namespace wangle {
 
 class FileRegion {


### PR DESCRIPTION
This is related with https://github.com/facebook/wangle/issues/6
I am not sure that removing FileRegion is really good(comparing to implement operation of splice)

splice works on only LINUX.
so I add #error to build fail when user use FileRegion.h
 