### PR TITLE
Changes for OS X support

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_CXX_FLAGS "-std=c++0x -fPIC")
+set(CMAKE_CXX_FLAGS "-std=c++14 -fPIC")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(Folly REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread filesystem)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
+find_library(GLOG_LIBRARY_PATH glog)
+find_library(GFLAGS_LIBRARY_PATH gflags)
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/..
@@ -80,8 +82,8 @@ target_link_libraries(wangle
   ${FOLLY_LIBRARIES}
   ${Boost_LIBRARIES}
   ${OPENSSL_LIBRARIES}
-  -lglog
-  -lgflags
+  ${GLOG_LIBRARY_PATH}
+  ${GFLAGS_LIBRARY_PATH}
   -latomic)
 
 install(TARGETS wangle DESTINATION lib)

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(wangle
   ${OPENSSL_LIBRARIES}
   ${GLOG_LIBRARY_PATH}
   ${GFLAGS_LIBRARY_PATH}
-  -latomic)
+  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:latomic>)
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_CXX_FLAGS "-std=c++14 -fPIC")
+set(CMAKE_CXX_FLAGS "-std=c++1y -fPIC")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(wangle
   ${OPENSSL_LIBRARIES}
   ${GLOG_LIBRARY_PATH}
   ${GFLAGS_LIBRARY_PATH}
-  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:latomic>)
+  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:-latomic>)
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})


### PR DESCRIPTION
I have made a few changes in order to get Wangle to build on OS X. There were 4 different problems which I've fixed in 4 different commits. The commit messages should be self-explanatory. The c++14 requirement might not be the best option to solve the compilation issue depending on the project's objective. Maybe the methods that relied on return type deduction should just specify their return type explicitly so as to remain c++11 compatible. I leave that to discussion.