### PR TITLE
Correct a typo in ctxSetupByOpensslFeature

### DIFF
--- a/wangle/ssl/SSLContextManager.cpp
+++ b/wangle/ssl/SSLContextManager.cpp
@@ -596,7 +596,7 @@ SSLContextManager::ctxSetupByOpensslFeature(
                 std::placeholders::_1));
   }
 #else
-  if (configs.ctxs.size() > 1) {
+  if (contexts.ctxs.size() > 1) {
     OPENSSL_MISSING_FEATURE(SNI);
   }
 #endif


### PR DESCRIPTION
I wasn't able to compile the newly pulled repo which seems to have been caused by a recent change introducing a typo which this commit corrects.