### PR TITLE
Enable building shared library

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -87,8 +87,7 @@ target_link_libraries(wangle
   ${Boost_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${GLOG_LIBRARY_PATH}
-  ${GFLAGS_LIBRARY_PATH}
-  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:-latomic>)
+  ${GFLAGS_LIBRARY_PATH})
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})

--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -77,10 +77,15 @@ set(WANGLE_SOURCES
   ssl/TLSTicketKeyManager.cpp
 )
 
-add_library(wangle STATIC
+add_library(wangle
   ${WANGLE_HEADERS}
   ${WANGLE_SOURCES}
 )
+
+if (BUILD_SHARED_LIBS)
+  set_target_properties(wangle
+    PROPERTIES VERSION 1.0.0 SOVERSION 1)
+endif()
 
 target_link_libraries(wangle
   ${FOLLY_LIBRARIES}


### PR DESCRIPTION
The only questionable part of these changes is removing `$<$<NOT:$<CXX_COMPILER_ID:Clang>>:-latomic>)`. Feel free to drop that hunk.