### PR TITLE
Support older versions of OpenSSL

### DIFF
--- a/wangle/acceptor/SSLAcceptorHandshakeHelper.cpp
+++ b/wangle/acceptor/SSLAcceptorHandshakeHelper.cpp
@@ -69,7 +69,7 @@ void SSLAcceptorHandshakeHelper::fillSSLTransportInfoFields(
 void SSLAcceptorHandshakeHelper::handshakeSuc(AsyncSSLSocket* sock) noexcept {
   const unsigned char* nextProto = nullptr;
   unsigned nextProtoLength = 0;
-  sock->getSelectedNextProtocol(&nextProto, &nextProtoLength);
+  sock->getSelectedNextProtocolNoThrow(&nextProto, &nextProtoLength);
   if (VLOG_IS_ON(3)) {
     if (nextProto) {
       VLOG(3) << "Client selected next protocol " <<


### PR DESCRIPTION
Use getSelectedNextProtocolNoThrow instead of getSelectedNextProtocol so
that the handshake can complete with older versions of OpenSSL that do
not support protocol negotiation.