### PR TITLE
Fix static linking

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -20,18 +20,27 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_package(Folly REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread filesystem)
+find_package(Boost REQUIRED COMPONENTS system thread filesystem regex context)
 find_package(OpenSSL REQUIRED)
+find_package(Glog REQUIRED)
+find_package(Gflags REQUIRED)
+find_package(Libevent REQUIRED)
+find_package(DoubleConversion REQUIRED)
 find_package(Threads REQUIRED)
-find_library(GLOG_LIBRARY_PATH glog)
-find_library(GFLAGS_LIBRARY_PATH gflags)
-find_library(DOUBLECONV_LIBRARY_PATH double-conversion)
+find_package(Libdl)
+find_package(Librt)
+
+include(CheckAtomic)
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/..
   ${FOLLY_INCLUDE_DIR}
-  ${BOOST_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIR}
   ${OPENSSL_INCLUDE_DIR}
+  ${GLOG_INCLUDE_DIRS}
+  ${GFLAGS_INCLUDE_DIRS}
+  ${LIBEVENT_INCLUDE_DIRS}
+  ${DOUBLE_CONVERSION_INCLUDE_DIRS}
   ${INCLUDE_DIR}
 )
 
@@ -104,9 +113,12 @@ target_link_libraries(wangle
   ${FOLLY_LIBRARIES}
   ${Boost_LIBRARIES}
   ${OPENSSL_LIBRARIES}
-  ${GLOG_LIBRARY_PATH}
-  ${GFLAGS_LIBRARY_PATH}
-  ${DOUBLECONV_LIBRARY_PATH})
+  ${GLOG_LIBRARIES}
+  ${GFLAGS_LIBRARIES}
+  ${LIBEVENT_LIBRARIES}
+  ${DOUBLE_CONVERSION_LIBRARIES}
+  ${LIBDL_LIBRARIES}
+  ${LIBRT_LIBRARIES})
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})

--- a/wangle/cmake/CheckAtomic.cmake
+++ b/wangle/cmake/CheckAtomic.cmake
@@ -1,0 +1,93 @@
+# University of Illinois/NCSA
+# Open Source License
+#
+# Copyright (c) 2003-2017 University of Illinois at Urbana-Champaign.
+# All rights reserved.
+#
+# Developed by:
+#
+#     LLVM Team
+#
+#     University of Illinois at Urbana-Champaign
+#
+#     http://llvm.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal with
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimers.
+#
+#     * Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimers in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the names of the LLVM Team, University of Illinois at
+#       Urbana-Champaign, nor the names of its contributors may be used to
+#       endorse or promote products derived from this Software without specific
+#       prior written permission.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+# SOFTWARE.
+
+include(CheckCXXSourceCompiles)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  get_directory_property(compile_options COMPILE_OPTIONS)
+  set(CMAKE_REQUIRED_FLAGS ${compile_options})
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+int main() {
+  struct Test { int val; };
+  std::atomic<Test> s;
+  s.is_lock_free();
+}" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics)
+
+
+if(NOT DEFINED PROXYGEN_COMPILER_IS_GCC_COMPATIBLE)
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(PROXYGEN_COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif(MSVC)
+    set(PROXYGEN_COMPILER_IS_GCC_COMPATIBLE OFF)
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(PROXYGEN_COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+    set(PROXYGEN_COMPILER_IS_GCC_COMPATIBLE ON)
+  endif()
+endif()
+
+# This isn't necessary on MSVC, so avoid command-line switch annoyance
+# by only running on GCC-like hosts.
+if(PROXYGEN_COMPILER_IS_GCC_COMPATIBLE)
+  # First check if atomics work without the library.
+  check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    check_library_exists(atomic __atomic_is_lock_free "" HAVE_LIBATOMIC)
+    if(HAVE_LIBATOMIC)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+      check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+      if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
+	message(FATAL_ERROR "Host compiler must support std::atomic!")
+      endif()
+      list(APPEND CMAKE_CXX_STANDARD_LIBRARIES -latomic)
+    else()
+      message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+    endif()
+  endif()
+endif()

--- a/wangle/cmake/FindDoubleConversion.cmake
+++ b/wangle/cmake/FindDoubleConversion.cmake
@@ -1,0 +1,25 @@
+# - Try to find double-conversion
+# Once done, this will define
+#
+# DOUBLE_CONVERSION_FOUND - system has double-conversion
+# DOUBLE_CONVERSION_INCLUDE_DIRS - the double-conversion include directories
+# DOUBLE_CONVERSION_LIBRARIES - link these to use double-conversion
+
+include(FindPackageHandleStandardArgs)
+
+find_library(DOUBLE_CONVERSION_LIBRARY double-conversion
+  PATHS ${DOUBLE_CONVERSION_LIBRARYDIR})
+
+find_path(DOUBLE_CONVERSION_INCLUDE_DIR double-conversion/double-conversion.h
+  PATHS ${DOUBLE_CONVERSION_INCLUDEDIR})
+
+find_package_handle_standard_args(double_conversion DEFAULT_MSG
+  DOUBLE_CONVERSION_LIBRARY
+  DOUBLE_CONVERSION_INCLUDE_DIR)
+
+mark_as_advanced(
+  DOUBLE_CONVERSION_LIBRARY
+  DOUBLE_CONVERSION_INCLUDE_DIR)
+
+set(DOUBLE_CONVERSION_LIBRARIES ${DOUBLE_CONVERSION_LIBRARY})
+set(DOUBLE_CONVERSION_INCLUDE_DIRS ${DOUBLE_CONVERSION_INCLUDE_DIR})

--- a/wangle/cmake/FindGflags.cmake
+++ b/wangle/cmake/FindGflags.cmake
@@ -1,0 +1,25 @@
+# - Try to find Gflags
+# Once done, this will define
+#
+# GFLAGS_FOUND - system has Gflags
+# GFLAGS_INCLUDE_DIRS - the Gflags include directories
+# GFLAGS_LIBRARIES - link these to use Gflags
+
+include(FindPackageHandleStandardArgs)
+
+find_library(GFLAGS_LIBRARY gflags
+  PATHS ${GFLAGS_LIBRARYDIR})
+
+find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+  PATHS ${GFLAGS_INCLUDEDIR})
+
+find_package_handle_standard_args(gflags DEFAULT_MSG
+  GFLAGS_LIBRARY
+  GFLAGS_INCLUDE_DIR)
+
+mark_as_advanced(
+  GFLAGS_LIBRARY
+  GFLAGS_INCLUDE_DIR)
+
+set(GFLAGS_LIBRARIES ${GFLAGS_LIBRARY})
+set(GFLAGS_INCLUDE_DIRS ${GFLAGS_INCLUDE_DIR})

--- a/wangle/cmake/FindGlog.cmake
+++ b/wangle/cmake/FindGlog.cmake
@@ -1,0 +1,25 @@
+# - Try to find Glog
+# Once done, this will define
+#
+# GLOG_FOUND - system has Glog
+# GLOG_INCLUDE_DIRS - the Glog include directories
+# GLOG_LIBRARIES - link these to use Glog
+
+include(FindPackageHandleStandardArgs)
+
+find_library(GLOG_LIBRARY glog
+  PATHS ${GLOG_LIBRARYDIR})
+
+find_path(GLOG_INCLUDE_DIR glog/logging.h
+  PATHS ${GLOG_INCLUDEDIR})
+
+find_package_handle_standard_args(glog DEFAULT_MSG
+  GLOG_LIBRARY
+  GLOG_INCLUDE_DIR)
+
+mark_as_advanced(
+  GLOG_LIBRARY
+  GLOG_INCLUDE_DIR)
+
+set(GLOG_LIBRARIES ${GLOG_LIBRARY})
+set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})

--- a/wangle/cmake/FindLibdl.cmake
+++ b/wangle/cmake/FindLibdl.cmake
@@ -1,0 +1,16 @@
+# - Try to find libdl
+# Once done, this will define
+#
+# LIBDL_FOUND - system has libdl
+# LIBDL_LIBRARIES - link these to use libdl
+
+include(FindPackageHandleStandardArgs)
+
+find_library(LIBDL_LIBRARY dl
+  PATHS ${LIBDL_LIBRARYDIR})
+
+find_package_handle_standard_args(libdl DEFAULT_MSG LIBDL_LIBRARY)
+
+mark_as_advanced(LIBDL_LIBRARY)
+
+set(LIBDL_LIBRARIES ${LIBDL_LIBRARY})

--- a/wangle/cmake/FindLibevent.cmake
+++ b/wangle/cmake/FindLibevent.cmake
@@ -1,0 +1,25 @@
+# - Try to find Libevent
+# Once done, this will define
+#
+# LIBEVENT_FOUND - system has Libevent
+# LIBEVENT_INCLUDE_DIRS - the Libevent include directories
+# LIBEVENT_LIBRARIES - link these to use Libevent
+
+include(FindPackageHandleStandardArgs)
+
+find_library(LIBEVENT_LIBRARY event
+  PATHS ${LIBEVENT_LIBRARYDIR})
+
+find_path(LIBEVENT_INCLUDE_DIR event.h
+  PATHS ${LIBEVENT_INCLUDEDIR})
+
+find_package_handle_standard_args(libevent DEFAULT_MSG
+  LIBEVENT_LIBRARY
+  LIBEVENT_INCLUDE_DIR)
+
+mark_as_advanced(
+  LIBEVENT_LIBRARY
+  LIBEVENT_INCLUDE_DIR)
+
+set(LIBEVENT_LIBRARIES ${LIBEVENT_LIBRARY})
+set(LIBEVENT_INCLUDE_DIRS ${LIBEVENT_INCLUDE_DIR})

--- a/wangle/cmake/FindLibrt.cmake
+++ b/wangle/cmake/FindLibrt.cmake
@@ -1,0 +1,16 @@
+# - Try to find librt
+# Once done, this will define
+#
+# LIBRT_FOUND - system has librt
+# LIBRT_LIBRARIES - link these to use librt
+
+include(FindPackageHandleStandardArgs)
+
+find_library(LIBRT_LIBRARY rt
+  PATHS ${LIBRT_LIBRARYDIR})
+
+find_package_handle_standard_args(librt DEFAULT_MSG LIBRT_LIBRARY)
+
+mark_as_advanced(LIBRT_LIBRARY)
+
+set(LIBRT_LIBRARIES ${LIBRT_LIBRARY})


### PR DESCRIPTION
I was trying to compile a static-only version of this library that links
with static versions of the dependencies. A few things seem to be
missing from the CMake configuration to make this possible.

The extra find_path commands allow for the (admittedly uncommon)
situation where every dependency is installed in a separate location.