### PR TITLE
Fix bug of PipelineBase::removeHelper

### DIFF
--- a/wangle/channel/Pipeline-inl.h
+++ b/wangle/channel/Pipeline-inl.h
@@ -69,7 +69,7 @@ template <class H>
 PipelineBase& PipelineBase::removeHelper(H* handler, bool checkEqual) {
   typedef typename ContextType<H>::type Context;
   bool removed = false;
-  for (auto it = ctxs_.begin(); it != ctxs_.end(); it++) {
+  for (auto it = ctxs_.begin(); it != ctxs_.end();){
     auto ctx = std::dynamic_pointer_cast<Context>(*it);
     if (ctx && (!checkEqual || ctx->getHandler() == handler)) {
       it = removeAt(it);
@@ -77,7 +77,9 @@ PipelineBase& PipelineBase::removeHelper(H* handler, bool checkEqual) {
       if (it == ctxs_.end()) {
         break;
       }
-    }
+    }else{
+     ++it;
+    }   
   }
 
   if (!removed) {

--- a/wangle/channel/Pipeline-inl.h
+++ b/wangle/channel/Pipeline-inl.h
@@ -69,18 +69,18 @@ template <class H>
 PipelineBase& PipelineBase::removeHelper(H* handler, bool checkEqual) {
   typedef typename ContextType<H>::type Context;
   bool removed = false;
-  for (auto it = ctxs_.begin(); it != ctxs_.end();){
-    auto ctx = std::dynamic_pointer_cast<Context>(*it);
-    if (ctx && (!checkEqual || ctx->getHandler() == handler)) {
-      it = removeAt(it);
-      removed = true;
-      if (it == ctxs_.end()) {
-        break;
+  auto unaryPredict = [&] (auto pipelineCtx) {
+      auto ctx = std::dynamic_pointer_cast<Context>(pipelineCtx);
+      if (ctx && (!checkEqual || ctx->getHandler() == handler)) {
+          removed = true;   
+          return true;
       }
-    }else{
-     ++it;
-    }   
-  }
+      return false;
+  };
+
+  ctxs_.erase(
+          std::remove_if(ctxs_.begin(), ctxs_.end(), unaryPredict),
+          ctxs_.end());
 
   if (!removed) {
     throw std::invalid_argument("No such handler in pipeline");


### PR DESCRIPTION
There is a bug when removeHelper's arguments is handler == nullptr and checkEqual== false.Because std::vecotr<>::erase will return a iterator following the last removed element, In this case the loop should't add it when the function named removeAt has executed.