### PR TITLE
Check existence of optional libraries before linking

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -116,9 +116,15 @@ target_link_libraries(wangle
   ${GLOG_LIBRARIES}
   ${GFLAGS_LIBRARIES}
   ${LIBEVENT_LIBRARIES}
-  ${DOUBLE_CONVERSION_LIBRARIES}
-  ${LIBDL_LIBRARIES}
-  ${LIBRT_LIBRARIES})
+  ${DOUBLE_CONVERSION_LIBRARIES})
+
+if (LIBDL_FOUND)
+  target_link_libraries(wangle ${LIBDL_LIBRARIES})
+endif ()
+
+if (LIBRT_FOUND)
+  target_link_libraries(wangle ${LIBRT_LIBRARIES})
+endif ()
 
 install(TARGETS wangle DESTINATION lib)
 foreach(dir ${WANGLE_HEADER_DIRS})


### PR DESCRIPTION
We need to check result of find_package before linking against them. 
For example, `librt` is NOT available in Mac and current CMakeLists.txt would cause compilation failure.