### PR TITLE
Allow access to tcpinfo on macOS, using tcp_connection_info

### DIFF
--- a/wangle/acceptor/TransportInfo.cpp
+++ b/wangle/acceptor/TransportInfo.cpp
@@ -86,6 +86,10 @@ int64_t TransportInfo::readRTT(const folly::AsyncSocket* sock) {
 #endif
 }
 
+#ifdef __APPLE__
+#define TCP_INFO TCP_CONNECTION_INFO;
+#endif
+
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 bool TransportInfo::readTcpInfo(tcp_info* tcpinfo,
                                 const folly::AsyncSocket* sock) {

--- a/wangle/acceptor/TransportInfo.cpp
+++ b/wangle/acceptor/TransportInfo.cpp
@@ -87,7 +87,7 @@ int64_t TransportInfo::readRTT(const folly::AsyncSocket* sock) {
 }
 
 #ifdef __APPLE__
-#define TCP_INFO TCP_CONNECTION_INFO;
+#define TCP_INFO TCP_CONNECTION_INFO
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)

--- a/wangle/acceptor/TransportInfo.h
+++ b/wangle/acceptor/TransportInfo.h
@@ -24,23 +24,6 @@
 #include <folly/SocketAddress.h>
 #include <folly/portability/Sockets.h>
 
-#ifdef __APPLE__
-#define tcp_info tcp_connection_info
-#define TCP_INFO TCP_CONNECTION_INFO
-#include <netinet/tcp_fsm.h>
-#define TCP_CLOSED       TCPS_CLOSED
-#define TCP_LISTEN       TCPS_LISTEN
-#define TCP_SYN_SENT     TCPS_SYN_SENT
-#define TCP_SYN_RECEIVED TCPS_SYN_RECEIVED
-#define TCP_ESTABLISHED  TCPS_ESTABLISHED
-#define TCP_CLOSE_WAIT   TCPS_CLOSE_WAIT
-#define TCP_FIN_WAIT_1   TCPS_FIN_WAIT_1
-#define TCP_CLOSING      TCPS_CLOSING
-#define TCP_LAST_ACK     TCPS_LAST_ACK
-#define TCP_FIN_WAIT_2   TCPS_FIN_WAIT_2
-#define TCP_TIME_WAIT    TCPS_TIME_WAIT
-#endif
-
 namespace folly {
 
 class AsyncSocket;
@@ -121,19 +104,16 @@ struct TransportInfo {
    */
   int64_t ssthresh{-1};
 
+#ifdef __APPLE__
+  typedef tcp_connection_info tcp_info;
+  static const int TCP_INFO = TCP_CONNECTION_INFO;
+#endif
+
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
-  /*
+/*
    * TCP information as fetched from getsockopt(2)
    */
-  tcp_info tcpinfo {
-#ifdef __APPLE__
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 // 38
-#elif __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 17
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 // 32
-#else
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 // 29
-#endif  // __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 17
-  };
+  tcp_info tcpinfo {};
 #endif  // defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 
   /*
@@ -432,7 +412,7 @@ struct TransportInfo {
   /*
    * perform the getsockopt(2) syscall to fetch TCP info for a given socket
    */
-  static bool readTcpInfo(struct tcp_info* tcpinfo,
+  static bool readTcpInfo(tcp_info* tcpinfo,
                           const folly::AsyncSocket* sock);
 #endif
 };

--- a/wangle/acceptor/TransportInfo.h
+++ b/wangle/acceptor/TransportInfo.h
@@ -106,7 +106,6 @@ struct TransportInfo {
 
 #ifdef __APPLE__
   typedef tcp_connection_info tcp_info;
-  static const int TCP_INFO = TCP_CONNECTION_INFO;
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)

--- a/wangle/acceptor/TransportInfo.h
+++ b/wangle/acceptor/TransportInfo.h
@@ -110,7 +110,7 @@ struct TransportInfo {
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
-/*
+  /*
    * TCP information as fetched from getsockopt(2)
    */
   tcp_info tcpinfo {};


### PR DESCRIPTION
On macOS, the `tcp_connection_info` struct provides almost the same information as the `tcp_info` struct on Linux and FreeBSD. With the help of a couple of `#ifdef`s, this pull request makes the `tcpinfo` field in `wangle::TransportInfo` available on macOS as well.

To further simplify getting the TCP state through `tcpinfo.tcpi_state` (which is my main motivation for doing this), I've added `#ifdef`s for the macOS values `TCPS_*` to the Linux/FreeBSD `TCP_*` macros.