### PR TITLE
Updated CMAKE_MODULE_PATH

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -11,7 +11,7 @@ project("wangle" VERSION 1.0.0 LANGUAGES CXX C)
 
 add_compile_options(-std=c++1y)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 
 # When installing Folly & Wangle in a non-default prefix, this will let
 # projects linking against libwangle.so to find libfolly.so automatically.


### PR DESCRIPTION
When wangle is embedded as subdirectory, CMAKE_SOURCE_DIR will point to the root project instead of wangle. Using CMAKE_CURRENT_SOURCE_DIR to make sure cmake finds correct module files.