### PR TITLE
fix gtest depency fallback

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -201,7 +201,7 @@ ENDIF(CMAKE_CROSSCOMPILING)
 if(BUILD_TESTS)
   enable_testing()
 
-  find_package(GMock MODULE REQUIRED)
+  find_package(GMock MODULE)
   if(NOT LIBGMOCK_FOUND)
     include(ExternalProject)
 


### PR DESCRIPTION
fixes issue where ExternalProject_Add in CMakeLists is unreachable
fixes #153