### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ ctest
 sudo make install
 ```
 
+## Building wangle - Using vcpkg
+
+You can download and install wangle using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install wangle
+
+The wangle port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Tutorial
 
 There is a tutorial [here](tutorial.md) that explains the basics of Wangle and shows how to build an echo server/client.


### PR DESCRIPTION
Wangle is available as a port in vcpkg, a C++ library manager that simplifies installation for wangle and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build wangle, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.