### PR TITLE
Support building under /build/ directories

### DIFF
--- a/wangle/CMakeLists.txt
+++ b/wangle/CMakeLists.txt
@@ -148,20 +148,22 @@ install(
 # =============================================================================
 
 # Collect all headers via recursive glob (like folly/fizz does)
-file(GLOB_RECURSE WANGLE_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+file(GLOB_RECURSE WANGLE_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 # Filter out test, facebook, and other non-public directories
-list(FILTER WANGLE_HEADERS EXCLUDE REGEX "/test/")
-list(FILTER WANGLE_HEADERS EXCLUDE REGEX "/facebook/")
-list(FILTER WANGLE_HEADERS EXCLUDE REGEX "/build/")
-list(FILTER WANGLE_HEADERS EXCLUDE REGEX "/example/")
+list(FILTER WANGLE_HEADERS EXCLUDE REGEX "(^|/)test/")
+list(FILTER WANGLE_HEADERS EXCLUDE REGEX "(^|/)facebook/")
+list(FILTER WANGLE_HEADERS EXCLUDE REGEX "(^|/)build/")
+list(FILTER WANGLE_HEADERS EXCLUDE REGEX "(^|/)example/")
 
 # Collect test headers separately
-file(GLOB_RECURSE WANGLE_TEST_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-list(FILTER WANGLE_TEST_HEADERS INCLUDE REGEX "/test/")
-list(FILTER WANGLE_TEST_HEADERS EXCLUDE REGEX "/facebook/")
+file(GLOB_RECURSE WANGLE_TEST_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+list(FILTER WANGLE_TEST_HEADERS INCLUDE REGEX "(^|/)test/")
+list(FILTER WANGLE_TEST_HEADERS EXCLUDE REGEX "(^|/)facebook/")
 
 # Install headers preserving directory structure
-wangle_install_headers(wangle ${CMAKE_CURRENT_SOURCE_DIR} ${WANGLE_HEADERS})
+wangle_install_headers(wangle . ${WANGLE_HEADERS})
 
 # =============================================================================
 # CMake package configuration

--- a/wangle/cmake/WangleFunctions.cmake
+++ b/wangle/cmake/WangleFunctions.cmake
@@ -13,26 +13,20 @@
 # limitations under the License.
 
 # Install header files preserving directory structure
-# Similar to folly's auto_install_files()
 function(wangle_install_headers rootName rootDir)
   file(TO_CMAKE_PATH "${rootDir}" rootDir)
-  string(LENGTH "${rootDir}" rootDirLength)
   foreach(fil ${ARGN})
     file(TO_CMAKE_PATH "${fil}" filePath)
-    string(FIND "${filePath}" "/" rIdx REVERSE)
-    if(rIdx EQUAL -1)
+
+    # dirname $fil
+    string(FIND "${filePath}" "/" lastSlash REVERSE)
+    if(lastSlash EQUAL -1)
       continue()
     endif()
-    string(SUBSTRING "${filePath}" 0 ${rIdx} filePath)
+    string(SUBSTRING "${filePath}" 0 ${lastSlash} dirName)
 
-    string(LENGTH "${filePath}" filePathLength)
-    string(FIND "${filePath}" "${rootDir}" rIdx)
-    if(rIdx EQUAL 0)
-      math(EXPR filePathLength "${filePathLength} - ${rootDirLength}")
-      string(SUBSTRING "${filePath}" ${rootDirLength} ${filePathLength} fileGroup)
-      install(FILES ${fil}
-              DESTINATION ${INCLUDE_INSTALL_DIR}/${rootName}${fileGroup})
-    endif()
+    install(FILES ${rootDir}/${fil}
+        DESTINATION ${INCLUDE_INSTALL_DIR}/${rootName}/${dirName})
   endforeach()
 endfunction()
 


### PR DESCRIPTION
Github PR 247[0] changed the way that wangle chose which headers to install. As part of this, certain directories, for example `/build/`, were filtered out.

Unfortunately this filtering is performed on the absolute path of the source code. If wangle is cloned underneath any directory which matches one of the filtered directories, then all the header files will be filtered out and no headers installed.

Fix this by changing the initial list to be relative to the source directory such that the filtering cannot mistakenly match on paths outside the wangle source tree.

[0] https://github.com/facebook/wangle/pull/247