### PR TITLE
Migrate wangle generate_cmake.py to shared library + add select() support

### DIFF
--- a/wangle/acceptor/CMakeLists.txt
+++ b/wangle/acceptor/CMakeLists.txt
@@ -50,6 +50,7 @@ wangle_add_library(wangle_acceptor
     Folly::folly_conv
     Folly::folly_glog
     Folly::folly_io_async_async_base
+    Folly::folly_io_async_fdsock_async_fd_socket
     Folly::folly_portability_gflags
     Folly::folly_portability_openssl
     Folly::folly_portability_sockets


### PR DESCRIPTION
Summary:
- Import shared parsing functions from opensource.buck_to_cmake.buck_parser
  instead of reimplementing extract_list, extract_external_deps, write_cmake_file
- Add select() support for deps/exported_deps using generate_select_deps_block
- Regenerate wangle/acceptor/CMakeLists.txt with newly discovered dep
  (Folly::folly_io_async_fdsock_async_fd_socket from select() branch)

Differential Revision: D95579502


