### PR TITLE
Fix typos in comments and tutorial docs

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -146,7 +146,7 @@ class EchoHandler : public HandlerAdapter<std::string> {
 };
 ```
 
-Notice that we override other methods — readException and readEOF. There are few other methods that can be overriden. If you need to handle a particular event, just override the corresponding virtual method.
+Notice that we override other methods — readException and readEOF. There are few other methods that can be overridden. If you need to handle a particular event, just override the corresponding virtual method.
 
 Now onto the client’s pipeline factory. It is identical the server’s pipeline factory apart from _EventBaseHandler_ — which handles writing data from an event loop thread.
 

--- a/wangle/acceptor/FizzConfigUtil.h
+++ b/wangle/acceptor/FizzConfigUtil.h
@@ -31,7 +31,7 @@ class FizzConfigUtil {
   /*
    * Adds certs to the cert manager from context configs.
    * If strictSSL is specified will throw on any failed cert load.
-   * Returns true if atleast one cert was successfully loaded
+   * Returns true if at least one cert was successfully loaded
    */
   static bool addCertsToManager(
       const std::vector<SSLContextConfig>& configs,

--- a/wangle/acceptor/test/ConnectionManagerTest.cpp
+++ b/wangle/acceptor/test/ConnectionManagerTest.cpp
@@ -259,7 +259,7 @@ TEST_F(ConnectionManagerTest, testDropEstablishedVerifyOrder) {
 
   // Initially connection will be added in decreasing order highest to lowest,
   // it will be N, N - 1, N - 2, ..., 1, 0, thats because we loop from (0, N)
-  // and push items at the begining of the loop. During drop connections we
+  // and push items at the beginning of the loop. During drop connections we
   // start from last item which will be lowest and we push them back to
   // identifiers vector, meaning everything will be sorted in increasing order
   ASSERT_TRUE(identifiers.size() >= 2);

--- a/wangle/ssl/TLSInMemoryTicketProcessor.h
+++ b/wangle/ssl/TLSInMemoryTicketProcessor.h
@@ -44,7 +44,7 @@ class TLSInMemoryTicketProcessor {
   virtual ~TLSInMemoryTicketProcessor();
   TLSTicketKeySeeds initInMemoryTicketSeeds();
 
-  /* Add a callback fucntion to be fired periodically. */
+  /* Add a callback function to be fired periodically. */
 
  private:
   void initScheduler();


### PR DESCRIPTION
## Summary

Fixes four typos found in code comments and the tutorial documentation. These are documentation-only changes — no code logic or behavior is touched.

## Changes

| File | Before | After |
|------|--------|-------|
| `wangle/ssl/TLSInMemoryTicketProcessor.h` | `Add a callback fucntion to be fired periodically.` | `Add a callback function to be fired periodically.` |
| `wangle/acceptor/FizzConfigUtil.h` | `Returns true if atleast one cert was successfully loaded` | `Returns true if at least one cert was successfully loaded` |
| `wangle/acceptor/test/ConnectionManagerTest.cpp` | `push items at the begining of the loop` | `push items at the beginning of the loop` |
| `tutorial.md` | `methods that can be overriden` | `methods that can be overridden` |

## Verification

Verified by inspection; each change touches only a comment or markdown prose. Re-grepping confirms no remaining occurrences of these typos.